### PR TITLE
fix: suppress num worker warning

### DIFF
--- a/docs/use_cases/libraries.md
+++ b/docs/use_cases/libraries.md
@@ -26,6 +26,10 @@ trainer.test(my_rul_estimator, dm)
 1. This should be a subclass of [LightningModule][pytorch_lightning.core.LightningModule].
 2. The trainer calls the data module's `prepare_data` and `setup` functions automatically.
 
+The RUL datasets library loads all data into memory at once and uses the main process for creating batches, i.e. `num_workers=0` for all dataloaders.
+When data is held in memory, multiple data loading processes are unnecessary and may even slow down training.
+The warning produced by PyTorch Lightning that `num_workers` is too low is, therefore, suppressed.
+
 ## PyTorch
 
 If you do not want to work with PyTorch Lightning, you can still use the RUL Dataset library in plain PyTorch.

--- a/rul_datasets/__init__.py
+++ b/rul_datasets/__init__.py
@@ -1,8 +1,14 @@
 __version__ = "0.0.0"
 
+import warnings
+
 from .adaption import DomainAdaptionDataModule, PretrainingAdaptionDataModule
 from .baseline import BaselineDataModule, PretrainingBaselineDataModule
-from .ssl import SemiSupervisedDataModule
 from .core import RulDataModule
 from .reader import CmapssReader, FemtoReader, XjtuSyReader
 from .reader.data_root import get_data_root, set_data_root
+from .ssl import SemiSupervisedDataModule
+
+warnings.filterwarnings(
+    "ignore", ".*Consider increasing the value of the `num_workers` argument*"
+)

--- a/rul_datasets/core.py
+++ b/rul_datasets/core.py
@@ -244,6 +244,9 @@ class RulDataModule(pl.LightningDataModule):
         configured to drop the last batch of the data if it would only contain one
         sample.
 
+        The whole split is held in memory. Therefore, the `num_workers` are set to
+        zero which uses the main process for creating batches.
+
         Args:
             *args: Ignored. Only for adhering to parent class interface.
             **kwargs: Ignored. Only for adhering to parent class interface.
@@ -269,6 +272,9 @@ class RulDataModule(pl.LightningDataModule):
         The data loader is configured to leave the data unshuffled. The `pin_memory`
         option is activated to achieve maximum transfer speed to the GPU.
 
+        The whole split is held in memory. Therefore, the `num_workers` are set to
+        zero which uses the main process for creating batches.
+
         Args:
             *args: Ignored. Only for adhering to parent class interface.
             **kwargs: Ignored. Only for adhering to parent class interface.
@@ -288,6 +294,9 @@ class RulDataModule(pl.LightningDataModule):
 
         The data loader is configured to leave the data unshuffled. The `pin_memory`
         option is activated to achieve maximum transfer speed to the GPU.
+
+        The whole split is held in memory. Therefore, the `num_workers` are set to
+        zero which uses the main process for creating batches.
 
         Args:
             *args: Ignored. Only for adhering to parent class interface.


### PR DESCRIPTION
PyTorch Lightning throws warnings if `num_workers` is low for data loaders. As we hold our data in memory, we don't need worker processes. Therefore, this PR will suppress the warning and adds documentation on why.