### PR TITLE
feat: consolidate window size with get compatible

### DIFF
--- a/rul_datasets/reader/xjtu_sy.py
+++ b/rul_datasets/reader/xjtu_sy.py
@@ -71,7 +71,7 @@ class XjtuSyReader(AbstractReader):
 
         Args:
             fd: Index of the selected sub-dataset
-            window_size: Size of the sliding window. Defaults to 2560.
+            window_size: Size of the sliding window. Defaults to 32768.
             max_rul: Maximum RUL value of targets.
             percent_broken: The maximum relative degradation per time series.
             percent_fail_runs: The percentage or index list of available time series.

--- a/tests/reader/test_abstract.py
+++ b/tests/reader/test_abstract.py
@@ -130,3 +130,14 @@ class TestAbstractLoader:
 
         assert this.is_mutually_exclusive(other) == success
         assert other.is_mutually_exclusive(this) == success
+
+    @pytest.mark.parametrize(
+        ["mode", "expected_this", "expected_other"],
+        [("override", 30, 30), ("min", 15, 15), ("none", 30, 15)],
+    )
+    def test_consolidate_window_size(self, mode, expected_this, expected_other):
+        this = DummyReader(1, window_size=30)
+        other = this.get_compatible(2, consolidate_window_size=mode)
+
+        assert this.window_size == expected_this
+        assert other.window_size == expected_other


### PR DESCRIPTION
When constructing a compatible reader with get_compatible the window size was previously set to the minimum of the original readers and the new readers default window size for both readers. Now there are options to only use the original readers window size or to let the new reader use its default one.