### PR TITLE
fix: ensure NCMAPSS scaling range is tuple

### DIFF
--- a/rul_datasets/reader/ncmapss.py
+++ b/rul_datasets/reader/ncmapss.py
@@ -123,7 +123,7 @@ class NCmapssReader(AbstractReader):
         truncate_degraded_only: bool = False,
         resolution_seconds: int = 1,
         padding_value: float = 0.0,
-        scaling_range: Optional[Tuple[int, int]] = (0, 1),
+        scaling_range: Tuple[int, int] = (0, 1),
     ) -> None:
         """
         Create a new reader for the New C-MAPSS dataset. The maximum RUL value is set

--- a/rul_datasets/reader/ncmapss.py
+++ b/rul_datasets/reader/ncmapss.py
@@ -173,7 +173,7 @@ class NCmapssReader(AbstractReader):
         self.run_split_dist = run_split_dist or self._get_default_split(self.fd)
         self.resolution_seconds = resolution_seconds
         self.padding_value = padding_value
-        self.scaling_range = scaling_range
+        self.scaling_range = tuple(scaling_range)
 
         if self.resolution_seconds > 1 and window_size is None:
             warnings.warn(

--- a/tests/reader/test_ncmapss.py
+++ b/tests/reader/test_ncmapss.py
@@ -158,3 +158,11 @@ def test_feature_select(prepared_ncmapss):
     features, _ = reader.load_complete_split("dev", "dev")
 
     assert features[0].shape[2] == 10
+
+
+@pytest.mark.parametrize("scaling_range", [(0, 1), [0, 1]])
+def test_scaling_range_is_tuple(scaling_range):
+    reader = NCmapssReader(1, scaling_range=scaling_range)
+
+    assert isinstance(reader.scaling_range, tuple)
+    assert reader.scaling_range == (0, 1)


### PR DESCRIPTION
If reader is constructed with list scaling range, it breaks scaler detection and fitting. This can happen by constructing a scaler from a wandb config, as it treats tuples as lists.